### PR TITLE
Cambios en la traducción de las conversaciones según contexto

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * [JimmyVaras](https://github.com/JimmyVaras)
 * [Jota_be](https://www.twitch.tv/jota_be)
 * [Keiran](https://github.com/darkcidx)
-* 𐒝órnacκ®
+* [𐒝órnacκ®](https://github.com/gauria)
 * [Sπeler](https://github.com/Spieler1ONE1)
 * [ZettaZ](https://github.com/zzettazz)
 

--- a/tools/config.json
+++ b/tools/config.json
@@ -1,0 +1,27 @@
+{
+  "versions": {
+    "latest": "v0.8.0-pre",
+    "all": [
+      "v0.8.0-pre",
+      "v0.7.0",
+      "v0.7.0-pre",
+      "v0.6.0",
+      "v0.6.0-pre",
+      "v0.5.0",
+      "v0.5.0-pre",
+      "v0.4.0",
+      "v0.3.4",
+      "v0.3.3"
+    ]
+  },
+  "lenguages": {
+    "es_ES": [
+      "Español (España)",
+      "spanish_(spain)"
+    ],
+    "en": [
+      "Inglés",
+      "english"
+    ]
+  }
+}


### PR DESCRIPTION
se sube numerosas líneas de dialogo, 
casi todas son comunicaciones de radio, he tenido problemas con una definición correcta de la palabra "Dispatch" que aparece numerosamente, según el contexto sería una especie de "recibido" o similar o así lo he interpretado, he buscado información de si es habitual en conversaciones de walkie talkie o similares, pero no he encontrado nada al respecto, si hay otra sugerencia comentármelo para cambiarla.

por otro lado, he visto que se ha traducido las líneas de comando del chat que no se si deberían mantener su palabra en ingles para que no den error los comandos, pero no lo he probado, como por ejemplo:
chat_command_party=fiesta
chat_command_party_disband=fiestadisolver
chat_command_party_invite=invitacion al grupo
chat_command_party_invite_error=Error.
chat_command_party_invite_not_found=Jugador no encontrado
chat_command_party_invite_sent=Invitacion al grupo enviada a
chat_command_party_invite_usage=Uso: /partyinvite (nombre del jugador)